### PR TITLE
add an error message to Covariance.covar

### DIFF
--- a/gstatsim.py
+++ b/gstatsim.py
@@ -591,18 +591,18 @@ class Covariance:
         Raises
         ------
         AtrributeError : if vtype is not 'Exponential', 'Gaussian', or 'Spherical'
-        
+
         Returns
         -------
             c : numpy.ndarray
                 covariance
         """
         
-        if vtype.lower() == 'Exponential':
+        if vtype.lower() == 'exponential':
             c = (sill - nug)*np.exp(-3 * effective_lag)
-        elif vtype.lower() == 'Gaussian':
+        elif vtype.lower() == 'gaussian':
             c = (sill - nug)*np.exp(-3 * np.square(effective_lag))
-        elif vtype.lower() == 'Spherical':
+        elif vtype.lower() == 'spherical':
             c = sill - nug - 1.5 * effective_lag + 0.5 * np.power(effective_lag, 3)
             c[effective_lag > 1] = sill - 1
         else: 

--- a/gstatsim.py
+++ b/gstatsim.py
@@ -595,13 +595,15 @@ class Covariance:
                 covariance
         """
         
-        if vtype == 'Exponential':
+        if vtype.lower() == 'Exponential':
             c = (sill - nug)*np.exp(-3 * effective_lag)
-        elif vtype == 'Gaussian':
+        elif vtype.lower() == 'Gaussian':
             c = (sill - nug)*np.exp(-3 * np.square(effective_lag))
-        elif vtype == 'Spherical':
+        elif vtype.lower() == 'Spherical':
             c = sill - nug - 1.5 * effective_lag + 0.5 * np.power(effective_lag, 3)
             c[effective_lag > 1] = sill - 1
+        else: 
+            raise AttributeError(f"vtype must be 'Exponential', 'Gaussian', or 'Spherical'")
         return c
 
     def make_covariance_matrix(coord, vario, rotation_matrix):

--- a/gstatsim.py
+++ b/gstatsim.py
@@ -588,6 +588,9 @@ class Covariance:
                 nugget of variogram
             vtype : string
                 type of variogram model (Exponential, Gaussian, or Spherical)
+        Raises
+        ------
+        AtrributeError : if vtype is not 'Exponential', 'Gaussian', or 'Spherical'
         
         Returns
         -------


### PR DESCRIPTION
Hi there,

This small PR adds a more expressive error message to `Covariance.covar` in case an unknown `vtype` is passed. Up to now, the local variable `c` is not instantiated and the line `return c` will return an error, indicating that `c` was referenced before assignment.
With these adaptions, a more expressive error message, describing the actual problem, is raised.

Additionally, I changed the the if-statements to be case insensitive. Thus, current behavior is not changed, but you can also pass the type like: `gs.Interpolation.okrige_sgs(..., vtype='spherical')`

What do you think?

Best,

Mirko